### PR TITLE
Replace twitter links with slack DM links

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -115,8 +115,8 @@ title: PhillyDev
 
     <h4>Organizers</h4>
 
-    <p>Jonathan Belcher <a href="https://twitter.com/belcherj">@belcherj</a> 
-      and Jenn Voss <a href="https://twitter.com/jvoss">@jvoss</a></p>
+    <p>Jonathan Belcher <a href="https://phillydev.slack.com/messages/@belcherj/">@belcherj</a>
+      and Jenn Voss <a href="https://phillydev.slack.com/messages/@jvoss/">@jvoss</a></p>
 
     <h3>License</h3>
 


### PR DESCRIPTION
Went in to fix my twitter handle which was incorrect,
but figured it was better off to have these link out
to direct Slack messages.
